### PR TITLE
[Fix] Overridden button background color

### DIFF
--- a/assets/styles/global.css
+++ b/assets/styles/global.css
@@ -347,7 +347,7 @@ svg {
 
 /** BUTTON **/
 .button {
-  background-color: #1890ff;
+  background-color: #1890ff !important;
   border-color: #1890ff;
   border-radius: 4px;
   border: 0;


### PR DESCRIPTION
In the newsletter page, the button's background color was being overridden by a transparent background rule.

Newsletter: [Link](https://midu.dev/newsletter/)

![Screenshot Bug](https://github.com/di4m0nds/midu.dev/assets/84233833/956a4493-03c6-47f8-a852-5975ef7244fe)
![Screenshot Fix](https://github.com/di4m0nds/midu.dev/assets/84233833/96446d45-f55b-47df-8126-4eacf495c315)

